### PR TITLE
statsの日付を正しく解釈する修正

### DIFF
--- a/src/main/scala/org/embulk/parser/twitter_ads_stats/define/Request.scala
+++ b/src/main/scala/org/embulk/parser/twitter_ads_stats/define/Request.scala
@@ -1,6 +1,6 @@
 package org.embulk.parser.twitter_ads_stats.define
 
-import java.time.{LocalDate, LocalDateTime}
+import java.time.LocalDate
 
 case class Request(
     params: Params
@@ -11,14 +11,15 @@ object Request {
 }
 
 case class Params(
-    start_time: LocalDateTime,
-    end_time: LocalDateTime,
+    start_time: StatsDateTime,
+    end_time: StatsDateTime,
     placement: String
 ) {
-  require(!start_time.isAfter(end_time))
+  require(!start_time.utcDateTime.isAfter(end_time.utcDateTime))
+  require(start_time.utcDateTime.toLocalTime == end_time.utcDateTime.toLocalTime)
 
-  val startDate = start_time.toLocalDate
-  val endDate   = end_time.toLocalDate
+  val startDate = start_time.adAccountLocalDate
+  val endDate   = end_time.adAccountLocalDate
 
   /**
     * MetricTimeSeries の期間

--- a/src/main/scala/org/embulk/parser/twitter_ads_stats/define/Request.scala
+++ b/src/main/scala/org/embulk/parser/twitter_ads_stats/define/Request.scala
@@ -15,8 +15,8 @@ case class Params(
     end_time: StatsDateTime,
     placement: String
 ) {
-  require(!start_time.utcDateTime.isAfter(end_time.utcDateTime))
-  require(start_time.utcDateTime.toLocalTime == end_time.utcDateTime.toLocalTime)
+  require(!start_time.isAfter(end_time))
+  require(start_time.isSameOffsetTime(end_time))
 
   val startDate = start_time.adAccountLocalDate
   val endDate   = end_time.adAccountLocalDate

--- a/src/main/scala/org/embulk/parser/twitter_ads_stats/define/RootJson.scala
+++ b/src/main/scala/org/embulk/parser/twitter_ads_stats/define/RootJson.scala
@@ -1,8 +1,5 @@
 package org.embulk.parser.twitter_ads_stats.define
 
-import java.time.LocalDateTime
-import java.time.format.DateTimeFormatter
-
 import org.embulk.parser.twitter_ads_stats.{MetricElementNames, MetricTimeSeries}
 import spray.json.{DefaultJsonProtocol, DeserializationException, JsArray, JsString, JsValue, RootJsonReader}
 
@@ -68,11 +65,9 @@ class RootJson(metricElementNames: MetricElementNames) extends DefaultJsonProtoc
         val fieldNames = Params.fieldNames.toList
         json.asJsObject.getFields(fieldNames: _*) match {
           case Seq(JsString(a), JsString(b), c) =>
-            val formatter = DateTimeFormatter.ISO_DATE_TIME
-            //todo DateTimeFormatterでフォーマットが出来ない場合の例外処理
             Params(
-              LocalDateTime.parse(a, formatter),
-              LocalDateTime.parse(b, formatter),
+              StatsDateTime(a),
+              StatsDateTime(b),
               c.convertTo[String]
             )
           case x => throw DeserializationException(msg = s"params can't deserialize json: $x", fieldNames = fieldNames)

--- a/src/main/scala/org/embulk/parser/twitter_ads_stats/define/StatsDateTime.scala
+++ b/src/main/scala/org/embulk/parser/twitter_ads_stats/define/StatsDateTime.scala
@@ -1,0 +1,21 @@
+package org.embulk.parser.twitter_ads_stats.define
+
+import java.time.{LocalDate, LocalDateTime}
+import java.time.format.DateTimeFormatter
+
+/**
+  * @param iso8601DateTime This datetime represents midnight in the timezone of the advertiser's account.
+  */
+case class StatsDateTime(iso8601DateTime: String) {
+
+  val utcDateTime: LocalDateTime = LocalDateTime.parse(iso8601DateTime, DateTimeFormatter.ISO_DATE_TIME)
+
+  def adAccountLocalDate: LocalDate = utcDateTime.plusHours(StatsDateTime.DateLineOffsetHours).toLocalDate
+
+}
+
+object StatsDateTime {
+
+  val DateLineOffsetHours = 12
+
+}

--- a/src/main/scala/org/embulk/parser/twitter_ads_stats/define/StatsDateTime.scala
+++ b/src/main/scala/org/embulk/parser/twitter_ads_stats/define/StatsDateTime.scala
@@ -8,9 +8,13 @@ import java.time.format.DateTimeFormatter
   */
 case class StatsDateTime(iso8601DateTime: String) {
 
-  val utcDateTime: LocalDateTime = LocalDateTime.parse(iso8601DateTime, DateTimeFormatter.ISO_DATE_TIME)
+  private val utcDateTime: LocalDateTime = LocalDateTime.parse(iso8601DateTime, DateTimeFormatter.ISO_DATE_TIME)
 
   def adAccountLocalDate: LocalDate = utcDateTime.plusHours(StatsDateTime.DateLineOffsetHours).toLocalDate
+
+  def isAfter(that: StatsDateTime): Boolean = this.utcDateTime.isAfter(that.utcDateTime)
+
+  def isSameOffsetTime(that: StatsDateTime): Boolean = this.utcDateTime.toLocalTime == that.utcDateTime.toLocalTime
 
 }
 

--- a/src/test/scala/org/embulk/parser/twitter_ads_stats/define/ParamsSpec.scala
+++ b/src/test/scala/org/embulk/parser/twitter_ads_stats/define/ParamsSpec.scala
@@ -1,12 +1,12 @@
 package org.embulk.parser.twitter_ads_stats.define
 
-import java.time.{LocalDate, LocalDateTime}
+import java.time.LocalDate
 
 import org.embulk.parser.twitter_ads_stats.UnitSpec
 
 class ParamsSpec extends UnitSpec {
   "開始日~(終了日-1)の日程を取得する" in {
-    val period = Params(LocalDateTime.of(2017, 1, 1, 0, 0, 0), LocalDateTime.of(2017, 1, 4, 23, 23, 23), "")
+    val period = Params(StatsDateTime("2016-12-31T15:00:00Z"), StatsDateTime("2017-01-03T15:00:00Z"), "")
     val actual = period.targetDates
     val expected = List(
       LocalDate.of(2017, 1, 1),
@@ -16,7 +16,7 @@ class ParamsSpec extends UnitSpec {
     assert(actual == expected)
   }
   "開始日から終了日までの全日程は、開始日から終了日が同一な場合は同一な日程となる" in {
-    val period = Params(LocalDateTime.of(2017, 1, 1, 0, 0, 0), LocalDateTime.of(2017, 1, 1, 23, 23, 23), "")
+    val period = Params(StatsDateTime("2016-12-31T15:00:00Z"), StatsDateTime("2017-01-01T15:00:00Z"), "")
     val actual = period.targetDates
     val expected = List(
       LocalDate.of(2017, 1, 1)

--- a/src/test/scala/org/embulk/parser/twitter_ads_stats/define/RootSpec.scala
+++ b/src/test/scala/org/embulk/parser/twitter_ads_stats/define/RootSpec.scala
@@ -175,8 +175,8 @@ class RootSpec extends UnitSpec {
     val actual = createRoot(
       Request(
         params = Params(
-          start_time = LocalDateTime.of(2017, 1, 1, 1, 1, 1),
-          end_time = LocalDateTime.of(2017, 1, 4, 1, 1, 1),
+          start_time = StatsDateTime("2017-01-01T01:01:01Z"),
+          end_time = StatsDateTime("2017-01-04T01:01:01Z"),
           placement = ""
         )
       )
@@ -201,8 +201,8 @@ class RootSpec extends UnitSpec {
     val actual = createRoot(
       Request(
         params = Params(
-          start_time = LocalDateTime.of(2017, 1, 1, 1, 1, 1),
-          end_time = LocalDateTime.of(2017, 1, 1, 1, 1, 1),
+          start_time = StatsDateTime("2017-01-01T01:01:01Z"),
+          end_time = StatsDateTime("2017-01-01T01:01:01Z"),
           placement = ""
         )
       )
@@ -265,8 +265,8 @@ object RootSpec {
   val defaultRoot: Root = createRoot(
     Request(
       params = Params(
-        start_time = LocalDateTime.of(2017, 1, 1, 1, 1, 1),
-        end_time = LocalDateTime.of(2017, 1, 3, 1, 1, 1),
+        start_time = StatsDateTime("2017-01-01T01:01:01Z"),
+        end_time = StatsDateTime("2017-01-03T01:01:01Z"),
         placement = ""
       )
     )

--- a/src/test/scala/org/embulk/parser/twitter_ads_stats/define/StatsDateTimeSpec.scala
+++ b/src/test/scala/org/embulk/parser/twitter_ads_stats/define/StatsDateTimeSpec.scala
@@ -1,0 +1,21 @@
+package org.embulk.parser.twitter_ads_stats.define
+
+import java.time.LocalDate
+
+import org.embulk.parser.twitter_ads_stats.UnitSpec
+
+class StatsDateTimeSpec extends UnitSpec {
+
+  "Twitter APIの日時パラメータをアドアカウントでのローカル日付に変換できる" should {
+    "2017-08-20T15:00:00Z は 2017/08/21になる(JST)" in {
+      assert(StatsDateTime("2017-08-20T15:00:00Z").adAccountLocalDate == LocalDate.of(2017, 8, 21))
+    }
+    "2017-08-20T08:00:00Z は 2017/08/20になる(PST)" in {
+      assert(StatsDateTime("2017-08-20T08:00:00Z").adAccountLocalDate == LocalDate.of(2017, 8, 20))
+    }
+    "2017-08-20T10:00:00Z は 2017/08/20になる(Pacific/Honolulu)" in {
+      assert(StatsDateTime("2017-08-20T10:00:00Z").adAccountLocalDate == LocalDate.of(2017, 8, 20))
+    }
+  }
+
+}


### PR DESCRIPTION
request paramsのstart_timeとend_timeは対象アドアカウントのタイムゾーンにおいての午前0時を指します。

参考：
https://developer.twitter.com/en/docs/ads/analytics/api-reference/asynchronous
https://developer.twitter.com/en/docs/ads/general/guides/timezones

start_timeとend_timeが午前0時を指していることを利用し、現地時間の日付を算出してstatsの対象日の日付とするように修正しました。
